### PR TITLE
Enable file search in AirDCPP indexer by setting file_type to 'any'.

### DIFF
--- a/src/NzbDrone.Core/Indexers/AirDCPP/AirDCPPProxy.cs
+++ b/src/NzbDrone.Core/Indexers/AirDCPP/AirDCPPProxy.cs
@@ -80,14 +80,16 @@ namespace NzbDrone.Core.Indexers.AirDCPP
             _logger.Debug($"Performing hub search for {searchTerm}");
             var searchRequest = BuildRequest().Resource($"search/{searchInstanceId}/hub_search").Post().Build();
 
-            var query = new CustomInfo
+               var query = new CustomInfo
             {
                 query = new QueryInfo
                 {
                     pattern = searchTerm,
-                    file_type "any"any"
+                    file_type = "any"
                 }
             };
+
+            
 
             searchRequest.SetContent(query.ToJson());
 

--- a/src/NzbDrone.Core/Indexers/AirDCPP/AirDCPPProxy.cs
+++ b/src/NzbDrone.Core/Indexers/AirDCPP/AirDCPPProxy.cs
@@ -85,7 +85,7 @@ namespace NzbDrone.Core.Indexers.AirDCPP
                 query = new QueryInfo
                 {
                     pattern = searchTerm,
-                    file_type = "directory"
+                    file_type "any"any"
                 }
             };
 


### PR DESCRIPTION
### Description

This pull request changes the Radarr AirDCPP indexer so that it searches for files instead of directories. The method `PerformHubSearch` in `AirDCPPProxy.cs` previously set `file_type` to `"directory"`, which caused the indexer to return only directory results. By setting `file_type` to `"any"`, Radarr will query the AirDCPP API for all file types, enabling it to list individual movie files with proper metadata.